### PR TITLE
Add identity filter to jq to capture full output

### DIFF
--- a/pia-port-forward.sh
+++ b/pia-port-forward.sh
@@ -160,7 +160,7 @@ get_payload_and_sig() {
 	if [ -s "${payloadFile}" ]; then
 		json="$(cat "${payloadFile}")"
 	else
-		json="$(sudo -u "${vpnUser}" -- curl --interface "${adaptorName}" --get --insecure --silent --show-error --fail --location --max-time "${curlMaxTime}" --data-urlencode "token=${authToken}" "https://${gatewayAddress}:19999/getSignature" | jq -Mre)"
+		json="$(sudo -u "${vpnUser}" -- curl --interface "${adaptorName}" --get --insecure --silent --show-error --fail --location --max-time "${curlMaxTime}" --data-urlencode "token=${authToken}" "https://${gatewayAddress}:19999/getSignature" | jq -Mre .)"
 
 		printf "%s" "${json}" > "${payloadFile}"
     	echo "| Acquired new Signature." 1>&2


### PR DESCRIPTION
Add the identity filter ('.') to jq in order to capture the full json output from the curl request. Fixes an issue where jq prematurely closes the pipe from curl causing the input to not be captured correctly when creating a new payload file from scratch.

Tested in a FreeNAS 11.2-RELEASEp15 pluginv2 jail